### PR TITLE
Update StripeExtension.php

### DIFF
--- a/Twig/StripeExtension.php
+++ b/Twig/StripeExtension.php
@@ -2,7 +2,7 @@
 
 namespace WMC\StripeBundle\Twig;
 
-class StripeExtension extends \Twig_Extension
+class StripeExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
 
     protected $publishableKey;


### PR DESCRIPTION
using globals without  Twig_Extension_GlobalsInterface is deprecated .  thanks!